### PR TITLE
Handle failed events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'aiohttp',
         'click',
         'setproctitle',
-        # temporary pin to old release: https://github.com/protocolbuffers/protobuf/issues/10051
-        'protobuf==3.20.1',
+        'protobuf',
     ]
 )

--- a/src/raythena/utils/bookkeeper.py
+++ b/src/raythena/utils/bookkeeper.py
@@ -553,7 +553,7 @@ class BookKeeper(object):
 
     def add_failed_range(self, evnt_range: EventRange, file):
 
-        input_file_for_range = evnt_range.PFN
+        input_file_for_range = os.path.basename(evnt_range.PFN)
         output_file_for_range = self._input_output_mapping[input_file_for_range]
 
         # case N-1 / 1-1 : we need to invalidate all the event ranges that should have been merged together

--- a/src/raythena/utils/bookkeeper.py
+++ b/src/raythena/utils/bookkeeper.py
@@ -232,7 +232,7 @@ class TaskStatus:
         if filename not in failed_dict:
             failed_dict[filename] = dict()
         failed_dict[filename][eventrange.eventRangeID] = TaskStatus.build_eventrange_dict(eventrange)
-        if eventrange.eventRangeID in self._status[TaskStatus.SIMULATED].get(filename,{}):
+        if eventrange.eventRangeID in self._status[TaskStatus.SIMULATED].get(filename, {}):
             del self._status[TaskStatus.SIMULATED][eventrange.eventRangeID]
 
     def get_nsimulated(self, filename=None) -> int:
@@ -514,13 +514,13 @@ class BookKeeper(object):
                 file_failed_ranges = failed_ranges.get(file)
                 # in n_to_one case, ranges from one input file all go into the same output file
                 # so if we have a single failed range from that file, the entire file can be flagged as failed
-                # in 1_to_n case, the input file is split in many output files so we can still partially process it.
+                # in 1_to_n case, the input file is split in many output files so we can still partially process it.
                 is_file_failed = file in failed_ranges and is_n_to_one
                 file_merging_ranges = merging_files.get(file)
                 for i in range(1, self._events_per_file + 1):
                     range_id = BookKeeper.generate_event_range_id(file, i)
                     event_range = EventRange(range_id, i, i, file, guid, scope)
-                    # the file is marked as failed; all event ranges in the file are failed
+                    # the file is marked as failed; all event ranges in the file are failed
                     if is_file_failed:
                         self.add_failed_range(event_range, file)
                         if file_failed_ranges is not None and range_id not in file_failed_ranges:

--- a/src/raythena/utils/bookkeeper.py
+++ b/src/raythena/utils/bookkeeper.py
@@ -477,7 +477,7 @@ class BookKeeper(object):
 
     @staticmethod
     def generate_event_range_id(file: str, n: str):
-        return f"{file}-n"
+        return f"{file}-{n}"
 
     def _generate_event_ranges(self, job: PandaJob, task_status: TaskStatus):
         """

--- a/src/raythena/utils/eventservice.py
+++ b/src/raythena/utils/eventservice.py
@@ -463,8 +463,7 @@ class EventRangeQueue(object):
         for r in ranges_update:
             range_id = r['eventRangeID']
             range_status = r['eventStatus']
-            if range_id not in self.event_ranges_by_id or \
-                    range_id in self.rangesID_by_state[EventRange.READY]:
+            if range_id not in self.event_ranges_by_id:
                 raise Exception()
             self.update_range_state(range_id, range_status)
 

--- a/src/raythena/utils/eventservice.py
+++ b/src/raythena/utils/eventservice.py
@@ -341,6 +341,7 @@ class EventRangeQueue(object):
         """
         self.event_ranges_by_id: Dict[str, EventRange] = dict()
         self.rangesID_by_state: Dict[str, Set[str]] = dict()
+        #only holds event ranges that are ready
         self.rangesID_by_file: Dict[str, Set[str]] = dict()
         self.event_ranges_count: Dict[str, int] = dict()
         for s in EventRange.STATES:

--- a/src/raythena/utils/eventservice.py
+++ b/src/raythena/utils/eventservice.py
@@ -451,9 +451,7 @@ class EventRangeQueue(object):
 
     def update_ranges(self, ranges_update: Sequence[EventRangeDef]) -> None:
         """
-        Process a range update sent by the payload by updating the range status to the new status. It is only
-        possible to update event ranges which are in the assigned, or failed state, trying to update an unassigned or
-         finished range will raise an exception
+        Process a range update sent by the payload by updating the range status to the new status.
 
         Args:
             ranges_update: update sent by the payload

--- a/src/raythena/utils/eventservice.py
+++ b/src/raythena/utils/eventservice.py
@@ -341,7 +341,7 @@ class EventRangeQueue(object):
         """
         self.event_ranges_by_id: Dict[str, EventRange] = dict()
         self.rangesID_by_state: Dict[str, Set[str]] = dict()
-        #only holds event ranges that are ready
+        # only holds event ranges that are ready
         self.rangesID_by_file: Dict[str, Set[str]] = dict()
         self.event_ranges_count: Dict[str, int] = dict()
         for s in EventRange.STATES:

--- a/src/raythena/utils/ray.py
+++ b/src/raythena/utils/ray.py
@@ -74,7 +74,7 @@ def setup_ray(config: Config) -> Any:
         ray_url = f"{config.ray['headip']}:{config.ray['redisport']}"
         return ray.init(address=ray_url, _redis_password=config.ray['redispassword'], log_to_driver=log_to_driver)
     else:
-        return ray.init(_system_config={"num_heartbeats_timeout": 60000}, log_to_driver=log_to_driver)
+        return ray.init(log_to_driver=log_to_driver)
 
 
 def shutdown_ray(config: Config) -> None:

--- a/tests/test_eventservice.py
+++ b/tests/test_eventservice.py
@@ -117,9 +117,6 @@ class TestEventRangeQueue:
         failed_ranges_update = EventRangeUpdate.build_from_dict(
             pandaID, sample_failed_rangeupdate)[pandaID][nsuccess:]
 
-        with pytest.raises(Exception):
-            ranges_queue.update_ranges(ranges_update)
-
         ranges_queue.get_next_ranges(nevents)
         ranges_queue.update_ranges(ranges_update)
         assert len(ranges_update) == ranges_queue.nranges_done()


### PR DESCRIPTION
Updated bookkeeping to correctly account for failed event:
* Do not simulate event that should be merged with a failed event
* Do not merge files if an event failed
* Retroactively mark simulated event as failed if an event that should have been merged with it failed